### PR TITLE
fixing input file encoding error

### DIFF
--- a/lt2ti.py
+++ b/lt2ti.py
@@ -485,7 +485,7 @@ class lt2circuiTikz:
         
         self.linecnt = 0;
         try :
-            fhs = open(fileandpath, mode='r', newline=None);
+            fhs = open(fileandpath, mode='r', newline=None, encoding='iso-8859-1');
         except Exception as e:
             print('could not open ASC file "'+fileandpath+'" (cwd="'+os.curdir+'")');
             return None;


### PR DESCRIPTION
The files generated by my version of LTspice (XVII, running on wine) is generating iso-8859-1 encoded files. This was causing a bug when using the script on linux. This change fixes it.